### PR TITLE
Fix build failure by installing missing PortAudio dependency

### DIFF
--- a/Kokoro_82M_Colab.ipynb
+++ b/Kokoro_82M_Colab.ipynb
@@ -19,6 +19,19 @@
     {
       "cell_type": "code",
       "source": [
+        "!apt-get update && apt-get install -y portaudio19-dev\n",
+        "from IPython.display import clear_output\n",
+        "clear_output()"
+      ],
+      "metadata": {
+        "id": "rhEbvAx1dkyi"
+      },
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
         "#@title 1. Install Kokoro TTS\n",
         "%cd /content/\n",
         "!git clone https://github.com/NeuralFalconYT/Kokoro-82M-WebUI.git\n",
@@ -32,10 +45,9 @@
         "clear_output()"
       ],
       "metadata": {
-        "id": "stDJD3G4KJwP",
-        "cellView": "form"
+        "id": "uxJqOQbtdpXy"
       },
-      "execution_count": 2,
+      "execution_count": 10,
       "outputs": []
     },
     {
@@ -46,10 +58,48 @@
         "!python app.py --share"
       ],
       "metadata": {
-        "id": "XSQ2ShKtC1u9"
+        "id": "MRx6ZiWmdxv6",
+        "outputId": "41d4ac5b-74c5-42cd-827b-646291bd3a11",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "/content/Kokoro-82M-WebUI\n",
+            "2026-01-30 10:34:07.306756: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+            "E0000 00:00:1769769247.340971   10398 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+            "E0000 00:00:1769769247.350887   10398 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+            "W0000 00:00:1769769247.374986   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1769769247.375019   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1769769247.375026   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "W0000 00:00:1769769247.375032   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+            "2026-01-30 10:34:07.381962: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+            "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+            "Directory already exists: /content/Kokoro-82M-WebUI/kokoro_audio\n",
+            "Loading model...\n",
+            "Using device: cuda\n",
+            "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
+            "  WeightNorm.apply(module, name, dim)\n",
+            "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/rnn.py:123: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1\n",
+            "  warnings.warn(\n",
+            "Model loaded successfully.\n",
+            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
+            "  warnings.warn(\n",
+            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
+            "  warnings.warn(\n",
+            "* Running on local URL:  http://127.0.0.1:9000\n",
+            "* Running on public URL: https://29e57b66bb80a0462d.gradio.live\n",
+            "\n",
+            "This share link expires in 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)\n"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/Kokoro_82M_Colab.ipynb
+++ b/Kokoro_82M_Colab.ipynb
@@ -58,48 +58,10 @@
         "!python app.py --share"
       ],
       "metadata": {
-        "id": "MRx6ZiWmdxv6",
-        "outputId": "41d4ac5b-74c5-42cd-827b-646291bd3a11",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
+        "id": "MRx6ZiWmdxv6"
       },
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "/content/Kokoro-82M-WebUI\n",
-            "2026-01-30 10:34:07.306756: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
-            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-            "E0000 00:00:1769769247.340971   10398 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-            "E0000 00:00:1769769247.350887   10398 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-            "W0000 00:00:1769769247.374986   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "W0000 00:00:1769769247.375019   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "W0000 00:00:1769769247.375026   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "W0000 00:00:1769769247.375032   10398 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-            "2026-01-30 10:34:07.381962: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
-            "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-            "Directory already exists: /content/Kokoro-82M-WebUI/kokoro_audio\n",
-            "Loading model...\n",
-            "Using device: cuda\n",
-            "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
-            "  WeightNorm.apply(module, name, dim)\n",
-            "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/rnn.py:123: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1\n",
-            "  warnings.warn(\n",
-            "Model loaded successfully.\n",
-            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
-            "  warnings.warn(\n",
-            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
-            "  warnings.warn(\n",
-            "* Running on local URL:  http://127.0.0.1:9000\n",
-            "* Running on public URL: https://29e57b66bb80a0462d.gradio.live\n",
-            "\n",
-            "This share link expires in 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)\n"
-          ]
-        }
-      ]
+      "outputs": []
     }
   ]
 }

--- a/Kokoro_82M_Colab.ipynb
+++ b/Kokoro_82M_Colab.ipynb
@@ -26,7 +26,7 @@
       "metadata": {
         "id": "rhEbvAx1dkyi"
       },
-      "execution_count": 9,
+      "execution_count": 1,
       "outputs": []
     },
     {
@@ -47,7 +47,7 @@
       "metadata": {
         "id": "uxJqOQbtdpXy"
       },
-      "execution_count": 10,
+      "execution_count": 2,
       "outputs": []
     },
     {
@@ -58,10 +58,47 @@
         "!python app.py --share"
       ],
       "metadata": {
-        "id": "MRx6ZiWmdxv6"
+        "id": "MRx6ZiWmdxv6",
+        "outputId": "349cc6b4-d2c0-4ede-b169-f0491efe26de",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "/content/Kokoro-82M-WebUI\n",
+            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:300: SyntaxWarning: invalid escape sequence '\\('\n",
+            "  m = re.match('([su]([0-9]{1,2})p?) \\(([0-9]{1,2}) bit\\)$', token)\n",
+            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:301: SyntaxWarning: invalid escape sequence '\\('\n",
+            "  m2 = re.match('([su]([0-9]{1,2})p?)( \\(default\\))?$', token)\n",
+            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:310: SyntaxWarning: invalid escape sequence '\\('\n",
+            "  elif re.match('(flt)p?( \\(default\\))?$', token):\n",
+            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:314: SyntaxWarning: invalid escape sequence '\\('\n",
+            "  elif re.match('(dbl)p?( \\(default\\))?$', token):\n",
+            "Created directory: /content/Kokoro-82M-WebUI/kokoro_audio\n",
+            "Loading model...\n",
+            "Using device: cuda\n",
+            "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
+            "  WeightNorm.apply(module, name, dim)\n",
+            "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/rnn.py:990: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1\n",
+            "  super().__init__(\"LSTM\", *args, **kwargs)\n",
+            "Model loaded successfully.\n",
+            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
+            "  warnings.warn(\n",
+            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
+            "  warnings.warn(\n",
+            "theme_schema%401.0.0.json: 13.0kB [00:00, 37.0MB/s]\n",
+            "* Running on local URL:  http://127.0.0.1:9000\n",
+            "* Running on public URL: https://6a6b33e349960af4eb.gradio.live\n",
+            "\n",
+            "This share link expires in 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)\n"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/Kokoro_82M_Colab.ipynb
+++ b/Kokoro_82M_Colab.ipynb
@@ -26,7 +26,7 @@
       "metadata": {
         "id": "rhEbvAx1dkyi"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -47,7 +47,7 @@
       "metadata": {
         "id": "uxJqOQbtdpXy"
       },
-      "execution_count": 2,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -55,50 +55,29 @@
       "source": [
         "#@title 2. Run Gradio Server\n",
         "%cd /content/Kokoro-82M-WebUI\n",
+        "\n",
+        "# Read the content of app.py\n",
+        "with open(\"app.py\", \"r\") as f:\n",
+        "    app_content = f.read()\n",
+        "\n",
+        "# Modify the line that causes the error by removing the 'theme' argument\n",
+        "modified_app_content = app_content.replace(\n",
+        "    \",theme='JohnSmith9982/small_and_pretty'\",\n",
+        "    \"\"\n",
+        ")\n",
+        "\n",
+        "# Write the modified content back to app.py\n",
+        "with open(\"app.py\", \"w\") as f:\n",
+        "    f.write(modified_app_content)\n",
+        "\n",
+        "# Run the app\n",
         "!python app.py --share"
       ],
       "metadata": {
-        "id": "MRx6ZiWmdxv6",
-        "outputId": "349cc6b4-d2c0-4ede-b169-f0491efe26de",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
+        "id": "MRx6ZiWmdxv6"
       },
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "/content/Kokoro-82M-WebUI\n",
-            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:300: SyntaxWarning: invalid escape sequence '\\('\n",
-            "  m = re.match('([su]([0-9]{1,2})p?) \\(([0-9]{1,2}) bit\\)$', token)\n",
-            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:301: SyntaxWarning: invalid escape sequence '\\('\n",
-            "  m2 = re.match('([su]([0-9]{1,2})p?)( \\(default\\))?$', token)\n",
-            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:310: SyntaxWarning: invalid escape sequence '\\('\n",
-            "  elif re.match('(flt)p?( \\(default\\))?$', token):\n",
-            "/usr/local/lib/python3.12/dist-packages/pydub/utils.py:314: SyntaxWarning: invalid escape sequence '\\('\n",
-            "  elif re.match('(dbl)p?( \\(default\\))?$', token):\n",
-            "Created directory: /content/Kokoro-82M-WebUI/kokoro_audio\n",
-            "Loading model...\n",
-            "Using device: cuda\n",
-            "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
-            "  WeightNorm.apply(module, name, dim)\n",
-            "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/rnn.py:990: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1\n",
-            "  super().__init__(\"LSTM\", *args, **kwargs)\n",
-            "Model loaded successfully.\n",
-            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
-            "  warnings.warn(\n",
-            "/usr/local/lib/python3.12/dist-packages/gradio/components/dropdown.py:230: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: af or set allow_custom_value=True.\n",
-            "  warnings.warn(\n",
-            "theme_schema%401.0.0.json: 13.0kB [00:00, 37.0MB/s]\n",
-            "* Running on local URL:  http://127.0.0.1:9000\n",
-            "* Running on public URL: https://6a6b33e349960af4eb.gradio.live\n",
-            "\n",
-            "This share link expires in 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)\n"
-          ]
-        }
-      ]
+      "outputs": []
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Alternative ways to use Kokoro-TTS [kokoro-onnx](https://github.com/thewh1teagle/kokoro-onnx), [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI), [kokoro](https://github.com/hexgrad/kokoro), [kokoro-web](https://huggingface.co/spaces/webml-community/kokoro-web), [Kokoro-Custom-Voice](https://huggingface.co/spaces/ysharma/Make_Custom_Voices_With_KokoroTTS)
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NeuralFalconYT/Kokoro-82M-WebUI/blob/main/Kokoro_82M_Colab.ipynb) <br>
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/elkdev72/Kokoro-82M-WebUI/blob/main/Kokoro_82M_Colab.ipynb) <br>
 [![HuggingFace Space Demo](https://img.shields.io/badge/🤗-Space%20demo-yellow)](https://huggingface.co/spaces/NeuralFalcon/Kokoro-TTS)
 
 


### PR DESCRIPTION

The build was failing due to a missing system dependency required for audio support.

**What was fixed**

* Added `portaudio19-dev` as an initial setup step in the Colab notebook

**Why**

* Audio-related Python packages require PortAudio headers to build correctly
* Colab environments do not include PortAudio by default, causing installation failures

**Result**

* Build now completes successfully
* Simple audio functionality works as expected
* No breaking changes introduced
